### PR TITLE
HF-92: 게시글 수정 및 삭제 중 게시글에 대한 권한이 있는지 확인하는 어노테이션 추가

### DIFF
--- a/src/main/java/gible/domain/post/repository/PostRepository.java
+++ b/src/main/java/gible/domain/post/repository/PostRepository.java
@@ -1,13 +1,18 @@
 package gible.domain.post.repository;
 
 import gible.domain.post.entity.Post;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.UUID;
 
 public interface PostRepository extends JpaRepository<Post, UUID> {
 
     Page<Post> findByTitleContaining(String search, Pageable pageable);
+
+    @Query("SELECT p.writer.id FROM Post p WHERE p.id = :postId")
+    UUID findWriterIdByPostId(@Param("postId") UUID postId);
 }

--- a/src/main/java/gible/domain/post/service/PostService.java
+++ b/src/main/java/gible/domain/post/service/PostService.java
@@ -9,6 +9,7 @@ import gible.domain.user.entity.User;
 import gible.domain.user.repository.UserRepository;
 import gible.exception.CustomException;
 import gible.exception.error.ErrorType;
+import gible.global.aop.annotation.AuthenticatedUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -62,6 +63,7 @@ public class PostService {
     }
 
     /* 게시글 수정 */
+    @AuthenticatedUser
     @Transactional
     public void updatePost(PostReq postReq, UUID postId) {
 
@@ -72,6 +74,7 @@ public class PostService {
     }
 
     /* 게시글 삭제 */
+    @AuthenticatedUser
     @Transactional
     public void deletePost(UUID postId) {
 

--- a/src/main/java/gible/global/aop/AuthenticatedUserAop.java
+++ b/src/main/java/gible/global/aop/AuthenticatedUserAop.java
@@ -1,0 +1,55 @@
+package gible.global.aop;
+
+import gible.domain.post.repository.PostRepository;
+import gible.domain.security.common.SecurityUserDetails;
+import gible.exception.CustomException;
+import gible.exception.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Aspect
+@Component
+public class AuthenticatedUserAop {
+
+    private final PostRepository postRepository;
+
+    @Around("@annotation(gible.global.aop.annotation.AuthenticatedUser)")
+    public Object authenticatedUser(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        Object[] args = joinPoint.getArgs();
+
+        SecurityUserDetails principalDetails =
+                (SecurityUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        UUID expectedUserId = principalDetails.getId();
+
+        for (Object arg : args) {
+            if (arg instanceof UUID) {
+                UUID postId = (UUID) arg;
+                verifyAuthentication(expectedUserId, postId);
+                break;
+            }
+        }
+
+        return joinPoint.proceed();
+    }
+
+    /* 게시글에 대한 권한 확인 메서드 */
+    private void verifyAuthentication(UUID expectedUserId, UUID postId) {
+
+        UUID actualUserId = postRepository.findWriterIdByPostId(postId);
+        if (actualUserId == null) {
+            throw new CustomException(ErrorType.POST_NOT_FOUND);
+        }
+
+        if (!expectedUserId.equals(actualUserId)) {
+            throw new CustomException(ErrorType.UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/gible/global/aop/annotation/AuthenticatedUser.java
+++ b/src/main/java/gible/global/aop/annotation/AuthenticatedUser.java
@@ -1,0 +1,11 @@
+package gible.global.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticatedUser {
+}

--- a/src/test/java/gible/post/service/PostServiceTest.java
+++ b/src/test/java/gible/post/service/PostServiceTest.java
@@ -198,36 +198,4 @@ public class PostServiceTest {
         assertEquals("제목1", postSummaryResPage.getContent().get(0).title());
         assertEquals("제목2", postSummaryResPage.getContent().get(1).title());
     }
-
-    @Test
-    @DisplayName("게시글 업데이트 테스트")
-    void updatePostTest() {
-        // given
-        PostReq updatePostReq =
-                new PostReq("제목수정", "내용수정", "주소수정", "이름수정", 30);
-
-        given(postRepository.findById(postId)).willReturn(Optional.ofNullable(post1));
-
-        // when
-        postService.updatePost(updatePostReq, postId);
-
-        // then
-        assertEquals("제목수정", post1.getTitle());
-        assertEquals("내용수정", post1.getContent());
-        assertEquals("주소수정", post1.getAddress());
-        assertEquals("이름수정", post1.getName());
-        assertEquals(30, post1.getWantedCard());
-    }
-
-    @Test
-    @DisplayName("게시글 삭제 테스트")
-    void deletePostTest() {
-        // given
-
-        // when
-        postService.deletePost(postId);
-
-        // then
-        verify(postRepository, times(1)).deleteById(postId);
-    }
 }

--- a/src/test/java/gible/post/service/SecuredPostServiceTest.java
+++ b/src/test/java/gible/post/service/SecuredPostServiceTest.java
@@ -1,0 +1,2 @@
+package gible.post.service;public class SecuredPostServiceTest {
+}

--- a/src/test/java/gible/post/service/SecuredPostServiceTest.java
+++ b/src/test/java/gible/post/service/SecuredPostServiceTest.java
@@ -1,2 +1,158 @@
-package gible.post.service;public class SecuredPostServiceTest {
+package gible.post.service;
+
+import gible.domain.post.dto.PostReq;
+import gible.domain.post.entity.Post;
+import gible.domain.post.repository.PostRepository;
+import gible.domain.post.service.PostService;
+import gible.domain.security.common.SecurityUserDetails;
+import gible.domain.user.entity.Role;
+import gible.domain.user.entity.User;
+import gible.domain.user.repository.UserRepository;
+import gible.exception.CustomException;
+import gible.exception.error.ErrorType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+public class SecuredPostServiceTest {
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private PostRepository postRepository;
+
+    @Autowired
+    private PostService postService;
+
+    private User user;
+
+    private UUID userId;
+    private UUID postId;
+
+    private Post post;
+    private PostReq updatePostReq;
+
+    @BeforeEach
+    void setUp() {
+        this.updatePostReq =
+                new PostReq("제목수정", "내용수정", "주소수정", "이름수정", 30);
+        this.userId = UUID.randomUUID();
+        this.postId = UUID.randomUUID();
+
+        this.user = User.builder()
+                .email("test@gmail.com")
+                .role(Role.USER)
+                .build();
+        setUserId(user, userId);
+
+        createPost();
+
+        SecurityUserDetails securityUserDetails = SecurityUserDetails.builder().user(user).build();
+        SecurityContextHolder.setContext(new SecurityContextImpl(new TestingAuthenticationToken(securityUserDetails, null)));
+    }
+
+    /* User의 id를 임의로 설정 */
+    private void setUserId(User user, UUID id) {
+        try {
+            Field idField = User.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(user, id);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void createPost() {
+        this.post = Post.builder()
+                .title("제목")
+                .content("내용")
+                .address("주소")
+                .name("작성자")
+                .wantedCard(20)
+                .writer(user)
+                .build();
+    }
+
+    @Test
+    @DisplayName("게시글 업데이트 테스트")
+    void updatePostTest() {
+        // given
+        given(postRepository.findById(postId)).willReturn(Optional.of(post));
+        given(postRepository.findWriterIdByPostId(postId)).willReturn(userId);
+
+        // when
+        postService.updatePost(updatePostReq, postId);
+
+        // then
+        assertEquals("제목수정", post.getTitle());
+        assertEquals("내용수정", post.getContent());
+        assertEquals("주소수정", post.getAddress());
+        assertEquals("이름수정", post.getName());
+        assertEquals(30, post.getWantedCard());
+    }
+
+    @Test
+    @DisplayName("게시글 업데이트 실패 테스트 - 권한 없음")
+    void updatePostFailedByUnauthorizedTest() {
+        // given
+        UUID otherUserId = UUID.randomUUID();
+
+        given(postRepository.findById(postId)).willReturn(Optional.of(post));
+        given(postRepository.findWriterIdByPostId(postId)).willReturn(otherUserId);
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            postService.updatePost(updatePostReq, postId);
+        });
+
+        // then
+        assertEquals(ErrorType.UNAUTHORIZED, exception.getErrortype());
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 테스트")
+    void deletePostTest() {
+        // given
+        given(postRepository.findWriterIdByPostId(postId)).willReturn(userId);
+
+        // when
+        postService.deletePost(postId);
+
+        // then
+        verify(postRepository, times(1)).deleteById(postId);
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 실패 테스트 - 권한 없음")
+    void deletePostFailedByUnauthorizedTest() {
+        // given
+        UUID otherUserId = UUID.randomUUID();
+        given(postRepository.findWriterIdByPostId(postId)).willReturn(otherUserId);
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            postService.deletePost(postId);
+        });
+
+        // then
+        assertEquals(ErrorType.UNAUTHORIZED, exception.getErrortype());
+    }
 }


### PR DESCRIPTION
## 개요
프론트에서 권한이 있는 사람만 접근하도록 허용할 수 있으나, 백엔드 api 엔드포인트를 통해 PostMan과 같은 api 플랫폼으로의 다이렉트 접근을 통한 요청에 대해서 대비를 하기 위해 구현.

## 구현사항
- 확인이 필요한 메서드에 붙힐 AuthenticatedUser 어노테이션 구현
- AuthenticatedUser이 사용되는 구간에 대한 aop 코드 작성
- 게시글 수정 및 삭제 메서드에 AuthenticatedUser 어노테이션 추가
- aop 동작 확인을 위한 Test 코드 작성

## 기타
PostMan으로라도 실행 결과를 보여주고 싶었으나 사용자에 로그인을 할 방법이 아직은 없어 비슷하게 적용한 프로젝트를 통해서 결과를 보여드리도록 하겠습니다.

만약, 자신이 작성한 글이 아닌데 글에 대한 업데이트, 삭제 등을 요청한다면 아래와 같은 결과가 나옴.

<img width="307" alt="스크린샷 2024-07-19 오전 1 12 57" src="https://github.com/user-attachments/assets/4d8706ab-2a57-4a83-b4d3-a8af37dcc8af">